### PR TITLE
[WIP] torch.jit support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,29 @@
 language: python
 stages:
-- quality-assurance
-- deploy
+- code-quality
+- tests
 cache: pip
 jobs:
   include:
-  - stage: quality-assurance
+  - stage: code-quality
     python: '3.6'
     install: pip install flake8
     script: flake8
 
-  - stage: quality-assurance
+  - stage: tests
     python: '3.6'
     before_install:
     - pip install pytest pytest-cov
     install:
     - python setup.py install
     script:
-    - pytest --cov dropblock --cov-report term-missing -v tests/
+    - PYTORCH_JIT=0 pytest --cov dropblock --cov-report term-missing -v tests/
+
+  - stage: tests
+    python: '3.6'
+    before_install:
+    - pip install pytest
+    install:
+    - python setup.py install
+    script:
+    - PYTORCH_JIT=1 pytest -v tests/

--- a/dropblock/dropblock.py
+++ b/dropblock/dropblock.py
@@ -1,9 +1,18 @@
 import torch
 import torch.nn.functional as F
-from torch import nn
 
 
-class DropBlock2D(nn.Module):
+if torch.__version__ >= '1.0.0':
+    Module = torch.jit.ScriptModule
+    script_method = torch.jit.script_method
+else:
+    Module = torch.nn.Module
+
+    def script_method(x):
+        return x
+
+
+class DropBlock2D(Module):
     r"""Randomly zeroes 2D spatial blocks of the input tensor.
 
     As described in the paper
@@ -24,12 +33,18 @@ class DropBlock2D(nn.Module):
 
     """
 
+    __constants__ = ['drop_prob', 'block_size', 'gamma']
+
     def __init__(self, drop_prob, block_size):
         super(DropBlock2D, self).__init__()
 
-        self.drop_prob = drop_prob
-        self.block_size = block_size
+        self.drop_prob = drop_prob  # type: float
+        self.block_size = block_size  # type: int
 
+        # get gamma value
+        self.gamma = self._compute_gamma()  # type: float
+
+    @script_method
     def forward(self, x):
         # shape: (bsize, channels, height, width)
 
@@ -37,30 +52,25 @@ class DropBlock2D(nn.Module):
             "Expected input with 4 dimensions (bsize, channels, height, width)"
 
         if not self.training or self.drop_prob == 0.:
-            return x
+            out = x
         else:
-            # get gamma value
-            gamma = self._compute_gamma(x)
-
             # sample mask
-            mask = (torch.rand(x.shape[0], *x.shape[2:]) < gamma).float()
-
-            # place mask on input device
-            mask = mask.to(x.device)
+            mask = (torch.rand(x.shape[0], x.shape[2], x.shape[3], device=x.device) < self.gamma).float()
 
             # compute block mask
             block_mask = self._compute_block_mask(mask)
 
             # apply block mask
-            out = x * block_mask[:, None, :, :]
+            out = x * block_mask.unsqueeze(1)
 
             # scale output
             out = out * block_mask.numel() / block_mask.sum()
 
-            return out
+        return out
 
+    @script_method
     def _compute_block_mask(self, mask):
-        block_mask = F.max_pool2d(input=mask[:, None, :, :],
+        block_mask = F.max_pool2d(input=mask.unsqueeze(1),
                                   kernel_size=(self.block_size, self.block_size),
                                   stride=(1, 1),
                                   padding=self.block_size // 2)
@@ -72,11 +82,11 @@ class DropBlock2D(nn.Module):
 
         return block_mask
 
-    def _compute_gamma(self, x):
+    def _compute_gamma(self):
         return self.drop_prob / (self.block_size ** 2)
 
 
-class DropBlock3D(DropBlock2D):
+class DropBlock3D(Module):
     r"""Randomly zeroes 3D spatial blocks of the input tensor.
 
     An extension to the concept described in the paper
@@ -97,9 +107,18 @@ class DropBlock3D(DropBlock2D):
 
     """
 
-    def __init__(self, drop_prob, block_size):
-        super(DropBlock3D, self).__init__(drop_prob, block_size)
+    __constants__ = ['drop_prob', 'block_size', 'gamma']
 
+    def __init__(self, drop_prob, block_size):
+        super(DropBlock3D, self).__init__()
+
+        self.drop_prob = drop_prob  # type: float
+        self.block_size = block_size  # type: int
+
+        # get gamma value
+        self.gamma = self._compute_gamma()  # type: float
+
+    @script_method
     def forward(self, x):
         # shape: (bsize, channels, depth, height, width)
 
@@ -107,30 +126,25 @@ class DropBlock3D(DropBlock2D):
             "Expected input with 5 dimensions (bsize, channels, depth, height, width)"
 
         if not self.training or self.drop_prob == 0.:
-            return x
+            out = x
         else:
-            # get gamma value
-            gamma = self._compute_gamma(x)
-
             # sample mask
-            mask = (torch.rand(x.shape[0], *x.shape[2:]) < gamma).float()
-
-            # place mask on input device
-            mask = mask.to(x.device)
+            mask = (torch.rand(x.shape[0], x.shape[2], x.shape[3], x.shape[4], device=x.device) < self.gamma).float()
 
             # compute block mask
             block_mask = self._compute_block_mask(mask)
 
             # apply block mask
-            out = x * block_mask[:, None, :, :, :]
+            out = x * block_mask.unsqueeze(1)
 
             # scale output
             out = out * block_mask.numel() / block_mask.sum()
 
-            return out
+        return out
 
+    @script_method
     def _compute_block_mask(self, mask):
-        block_mask = F.max_pool3d(input=mask[:, None, :, :, :],
+        block_mask = F.max_pool3d(input=mask.unsqueeze(1),
                                   kernel_size=(self.block_size, self.block_size, self.block_size),
                                   stride=(1, 1, 1),
                                   padding=self.block_size // 2)
@@ -142,5 +156,5 @@ class DropBlock3D(DropBlock2D):
 
         return block_mask
 
-    def _compute_gamma(self, x):
+    def _compute_gamma(self):
         return self.drop_prob / (self.block_size ** 3)

--- a/tests/test_dropblock2d.py
+++ b/tests/test_dropblock2d.py
@@ -1,3 +1,4 @@
+import os
 from unittest import mock
 
 import pytest
@@ -136,6 +137,7 @@ def test_block_mask_overlap():
 
 
 # noinspection PyCallingNonCallable
+@pytest.mark.skipif(os.environ.get('PYTORCH_JIT', '1') == '1', reason="PYTORCH_JIT enabled")
 def test_forward_pass():
     db = DropBlock2D(block_size=3, drop_prob=0.1)
     block_mask = torch.tensor([[[0., 0., 0., 1., 1., 1., 1.],

--- a/tests/test_dropblock3d.py
+++ b/tests/test_dropblock3d.py
@@ -1,7 +1,10 @@
-import torch
-from dropblock import DropBlock3D
+import os
 from unittest import mock
+
 import pytest
+import torch
+
+from dropblock import DropBlock3D
 
 
 # noinspection PyCallingNonCallable
@@ -123,6 +126,7 @@ def test_block_mask_cube_odd():
 
 
 # noinspection PyCallingNonCallable
+@pytest.mark.skipif(os.environ.get('PYTORCH_JIT', '1') == '1', reason="PYTORCH_JIT enabled")
 def test_forward_pass():
     db = DropBlock3D(block_size=3, drop_prob=0.1)
     block_mask = torch.tensor([[[[1., 1., 1., 1., 1., 1., 1.],


### PR DESCRIPTION
Refactor of `DropBlock2D` and `DropBlock3D` in TorchScript, while maintaining backwards compatibility.

Fixes #25 

**To Do:**
- [x] convert DropBlock2D
- [x] convert DropBlock3D
- [ ] convert LinearScheduler